### PR TITLE
Delete reference to email in AddCommandTest

### DIFF
--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -54,26 +54,6 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_duplicateName_throwsCommandException() {
-        // existing person in model
-        Person existing = new PersonBuilder()
-                .withName("Alice Pauline")
-                .withPhone("94351253")
-                .withAddress("123, Jurong West Ave 6").build();
-        ModelStub modelStub = new ModelStubWithPerson(existing);
-
-        Person dup = new PersonBuilder()
-                .withName("Alice Pauline")
-                .withPhone("99999999")
-                .withAddress("Somewhere else")
-                .withTags("friend").build();
-
-        AddCommand addCommand = new AddCommand(dup);
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
-    }
-
-
-    @Test
     public void equals() {
         Person alice = new PersonBuilder().withName("Alice").build();
         Person bob = new PersonBuilder().withName("Bob").build();


### PR DESCRIPTION
Reference to email field causes compilation errors as email field no longer exists. Deleted lines that refer to email.

Closes https://github.com/AY2526S1-CS2103T-F14b-2/tp/issues/109